### PR TITLE
Remove "insecure content" warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <script src="/js/taskforce.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js"></script>
 
-  <link href='http://fonts.googleapis.com/css?family=Lato:300|PT+Serif:400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:300|PT+Serif:400,700' rel='stylesheet' type='text/css'>
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.2/css/font-awesome.css" rel="stylesheet">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/css/bootstrap.min.css"> 
   <link href="/css/styles.css" rel="stylesheet">

--- a/join.html
+++ b/join.html
@@ -11,7 +11,7 @@
   <script src="/js/taskforce.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js"></script>
 
-  <link href='http://fonts.googleapis.com/css?family=Lato:300|PT+Serif:400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:300|PT+Serif:400,700' rel='stylesheet' type='text/css'>
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.2/css/font-awesome.css" rel="stylesheet">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/css/bootstrap.min.css"> 
   <link href="/css/styles.css" rel="stylesheet">


### PR DESCRIPTION
When viewed over SSL, taskforce.is would give an insecure content warning because the Google Fonts link was plain http. I changed the Fonts urls on index.html and join.html to be protocol relative.
